### PR TITLE
Add top bar for dictation screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/cotrin8672/inglyph/compose/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/cotrin8672/inglyph/compose/App.kt
@@ -2,14 +2,21 @@ package io.github.cotrin8672.inglyph.compose
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import io.github.cotrin8672.inglyph.DictationPractice
 import io.github.cotrin8672.inglyph.Home
 import io.github.cotrin8672.inglyph.compose.screen.DictationScreen
@@ -20,12 +27,18 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Preview
 fun App() {
     val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val canNavigateBack = navController.previousBackStackEntry != null
 
     MaterialTheme {
         Scaffold(
-            topBar = {}
-        ) {
-            Box(modifier = Modifier.padding(it)) {
+            topBar = {
+                if (canNavigateBack) {
+                    TopBar { navController.popBackStack() }
+                }
+            }
+        ) { padding ->
+            Box(modifier = Modifier.padding(padding)) {
                 AppNavHost(navController)
             }
         }
@@ -53,6 +66,16 @@ fun AppNavHost(
 
 @Preview
 @Composable
-fun TopBar() {
-
+fun TopBar(onBack: () -> Unit = {}) {
+    CenterAlignedTopAppBar(
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = "Back"
+                )
+            }
+        },
+        title = {}
+    )
 }


### PR DESCRIPTION
## Summary
- show a back button when navigating away from Home
- implement `TopBar` composable using `CenterAlignedTopAppBar`

## Testing
- `bash ./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d50f4fadc832ba94b5164d3dcd2c2